### PR TITLE
Add namespace to helm template filename

### DIFF
--- a/utils/bin/make-chart
+++ b/utils/bin/make-chart
@@ -42,9 +42,10 @@ def main(name, directory):
     # For each YAML document in the stdin, write it to a separate file in the given directory
     # CRDs go in the crds directory and everything else in the chart's templates directory
     for document in yaml.safe_load_all(sys.stdin):
-        filename = "{}_{}_{}.yaml".format(
+        filename = "{}_{}_{}_{}.yaml".format(
             document["apiVersion"].replace("/", "_"),
             document["kind"].lower(),
+            document["metadata"].get("namespace", ""),
             document["metadata"]["name"]
         )
         if document["kind"] == "CustomResourceDefinition":


### PR DESCRIPTION
Manifests with identical `apiVersion`,`kind` and `name` can create resources in different namespaces. Currently, only the resource that `kustomize`/`kubectl` evaluates last is created by `helm upgrade --install`, because the template files of the preceding resources are overwritten by later ones.

This adds resource `namespace` (if it exists) to the helm template filename created by `make-chart` to disambiguate identical resources created in different namespaces.