### PR TITLE
Add ServiceMonitor for Nvidia DCGM exporter

### DIFF
--- a/charts/cluster-addons/grafana-dashboards/nvidia-dcgm-exporter-dashboard_rev2.json
+++ b/charts/cluster-addons/grafana-dashboards/nvidia-dcgm-exporter-dashboard_rev2.json
@@ -1,7 +1,7 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
+      "name": "Prometheus",
       "label": "Prometheus",
       "description": "",
       "type": "datasource",
@@ -62,7 +62,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -149,7 +149,7 @@
       }
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 8,
         "w": 6,
@@ -214,7 +214,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -302,7 +302,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 8,
         "w": 6,
@@ -369,7 +369,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -464,7 +464,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -554,7 +554,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -643,7 +643,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -738,7 +738,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "Prometheus",
         "definition": "label_values(DCGM_FI_DEV_GPU_TEMP, instance)",
         "hide": 0,
         "includeAll": false,
@@ -760,7 +760,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "Prometheus",
         "definition": "label_values(gpu)",
         "hide": 0,
         "includeAll": true,

--- a/charts/cluster-addons/templates/kube-prometheus-stack.yaml
+++ b/charts/cluster-addons/templates/kube-prometheus-stack.yaml
@@ -2,6 +2,7 @@
 {{- include "cluster-addons.job.defaults" (list . "kube-prometheus-stack") }}
 installType: helm
 helm: {{ toYaml .Values.monitoring.kubePrometheusStack | nindent 2 }}
+{{- if .Values.nvidiaGpuOperator.enabled }}
 extraFiles:
   configmap-nvidia-dcgm-exporter-dashboard.yaml: |
     apiVersion: v1
@@ -15,11 +16,35 @@ extraFiles:
     data:
       nvidia-dcgm-exporter-dashboard.json: |
         {{- .Files.Get "grafana-dashboards/nvidia-dcgm-exporter-dashboard_rev2.json" | nindent 8 }}
+
+  servicemonitor-nvidia-dcgm-exporter.yaml: |
+    apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: gpu-operator-dcgm-exporter
+      namespace: {{ .Values.monitoring.nvidiaGPUOperator.release.namespace }}
+      labels:
+        {{- include "cluster-addons.labels" . | nindent 8 }}
+    spec:
+      endpoints:
+        - interval: 10s
+          path: /metrics
+          port: gpu-metrics
+      namespaceSelector:
+        matchNames:
+          - gpu-operator
+      selector:
+        matchLabels:
+          app: nvidia-dcgm-exporter
+
 hooks:
   postInstall: |
     kubectl apply -f ./configmap-nvidia-dcgm-exporter-dashboard.yaml
+    kubectl apply -f ./servicemonitor-nvidia-dcgm-exporter.yaml
   preDelete: |
     kubectl delete -f ./configmap-nvidia-dcgm-exporter-dashboard.yaml
+    kubectl delete -f ./servicemonitor-nvidia-dcgm-exporter.yaml
+{{- end }}
 {{- end }}
 
 {{-


### PR DESCRIPTION
The GPU operator doesn't deploy one yet (https://github.com/NVIDIA/gpu-operator/issues/305), so Prometheus doesn't know about the metrics endpoint exposed by the nvidia-dcgm-exporter. This adds config for a ServiceMonitor, gated behind `.Values.nvidiaGpuOperator.enabled`.

Also brings a small fix for Prometheus datasource names that breaks the dcgm-exporter-grafana-dashboard.