### PR TITLE
[cilium] Switch the IPAM mode to the default

### DIFF
--- a/charts/cluster-addons/templates/cni/cilium.yaml
+++ b/charts/cluster-addons/templates/cni/cilium.yaml
@@ -9,8 +9,6 @@ metadata:
     addons.stackhpc.com/watch: ""
 stringData:
   defaults: |
-    ipam:
-      mode: kubernetes
   overrides: |
     {{- toYaml .Values.cni.cilium.release.values | nindent 4 }}
 ---


### PR DESCRIPTION
The default IPAM mode with Cilium is [cluster scope](https://docs.cilium.io/en/stable/concepts/networking/ipam/), this commit switches back to this default so that there are no surprises when provisioning a cluster (i.e if you don't annotate nodes)