### PR TITLE
Allow the specification of additional storage classes

### DIFF
--- a/charts/cluster-addons/templates/openstack/csi-cinder.yaml
+++ b/charts/cluster-addons/templates/openstack/csi-cinder.yaml
@@ -52,7 +52,7 @@ spec:
     - secret:
         name: {{ include "cluster-addons.componentName" (list . "csi-cinder") }}-config
         key: overrides
-{{- if .Values.openstack.csiCinder.storageClass.enabled }}
+{{- if .Values.openstack.csiCinder.defaultStorageClass.enabled }}
 ---
 apiVersion: addons.stackhpc.com/v1alpha1
 kind: Manifests
@@ -66,15 +66,13 @@ spec:
   releaseName: csi-cinder-storageclass
   manifestSources:
     - template: |
-        {{- with .Values.openstack.csiCinder.storageClass }}
+        {{- with .Values.openstack.csiCinder.defaultStorageClass }}
         apiVersion: storage.k8s.io/v1
         kind: StorageClass
         metadata:
           name: {{ .name }}
-          {{- if .isDefault }}
           annotations:
             storageclass.kubernetes.io/is-default-class: "true"
-          {{- end }}
         provisioner: cinder.csi.openstack.org
         parameters:
           availability: {{ .availabilityZone }}
@@ -88,5 +86,39 @@ spec:
         allowedTopologies: {{ toYaml . | nindent 6 }}
         {{- end }}
         {{- end }}
+{{- end }}
+{{- range .Values.openstack.csiCinder.additionalStorageClasses }}
+{{- $rangeItem := . -}}
+{{- with $ }}
+---
+apiVersion: addons.stackhpc.com/v1alpha1
+kind: Manifests
+metadata:
+  name: {{ include "cluster-addons.componentName" (list . "csi-cinder-storageclass") }}
+  labels: {{ include "cluster-addons.componentLabels" (list . "csi-cinder-storageclass") | nindent 4 }}
+spec:
+  clusterName: {{ include "cluster-addons.clusterName" . }}
+  bootstrap: true
+  targetNamespace: {{ .Values.openstack.targetNamespace }}
+  releaseName: {{ $rangeItem.name }}-storageclass
+  manifestSources:
+    - template: |
+        apiVersion: storage.k8s.io/v1
+        kind: StorageClass
+        metadata:
+          name: {{ $rangeItem.name }}
+        provisioner: cinder.csi.openstack.org
+        parameters:
+          availability: {{ $rangeItem.availabilityZone }}
+          {{- with $rangeItem.volumeType }}
+          type: {{ . }}
+          {{- end }}
+        reclaimPolicy: {{ $rangeItem.reclaimPolicy }}
+        allowVolumeExpansion: {{ $rangeItem.allowVolumeExpansion }}
+        volumeBindingMode: WaitForFirstConsumer
+        {{- with $rangeItem.allowedTopologies }}
+        allowedTopologies: {{ toYaml . | nindent 6 }}
+        {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -87,14 +87,12 @@ openstack:
       name: openstack-cinder-csi
       version: 2.2.0
     values: {}
-    # Variables affecting the definition of the storage class
-    storageClass:
+    # Variables affecting the definition of the default storage class
+    defaultStorageClass:
       # Indicates if the storage class should be enabled
       enabled: true
       # The name of the storage class
       name: csi-cinder
-      # Indicates if the storage class should be annotated as the default storage class
-      isDefault: true
       # The reclaim policy for the storage class
       reclaimPolicy: Delete
       # Indicates if volume expansion is allowed
@@ -106,6 +104,20 @@ openstack:
       volumeType:
       # The allowed topologies for the storage class
       allowedTopologies:
+    # Variables affecting the definition of additional (non-default) storage classes
+    additionalStorageClasses: []
+      # - name: csi-cinder-fast
+      #   # The reclaim policy for the storage class
+      #   reclaimPolicy: Delete
+      #   # Indicates if volume expansion is allowed
+      #   allowVolumeExpansion: true
+      #   # The Cinder availability zone to use for volumes provisioned by the storage class
+      #   availabilityZone: nova
+      #   # The Cinder volume type to use for volumes provisioned by the storage class
+      #   # If not given, the default volume type will be used
+      #   volumeType: fast
+      #   # The allowed topologies for the storage class
+      #   allowedTopologies:
 
 # Settings for the metrics server
 # https://github.com/kubernetes-sigs/metrics-server#helm-chart


### PR DESCRIPTION
Renames the `storageClass` to `defaultStorageClass`, and adds an `additionalStorageClasses` variable.

Useful for clouds that have multiple volume types with particular performance characteristics.