### PR TITLE
Enable Nvidia ServiceMonitor

### DIFF
--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -249,7 +249,10 @@ nvidiaGPUOperator:
     version: v22.9.1
   release:
     namespace: gpu-operator
-    values: {}
+    values:
+      dcgmExporter:
+        serviceMonitor:
+          enabled: true
 
 # Settings for the Mellanox network operator
 mellanoxNetworkOperator:


### PR DESCRIPTION
Supersedes #5 I guess? Tested on a helm installed capi-cluster and verified that GPU metrics now appear in Grafana.