### PR TITLE
Make rootVolume dependent on disk size being specified

### DIFF
--- a/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
@@ -13,8 +13,8 @@ template:
     {{- with .Values.machineSSHKeyName }}
     sshKeyName: {{ . }}
     {{- end }}
-    {{- with .Values.controlPlane.machineRootVolume }}
-    rootVolume: {{ toYaml . | nindent 6 }}
+    {{- if .Values.controlPlane.machineRootVolume.diskSize }}
+    rootVolume: {{ toYaml .Values.controlPlane.machineRootVolume | nindent 6 }}
     {{- end }}
     {{- if .Values.machineImageId }}
     imageUUID: {{ .Values.machineImageId }}

--- a/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
@@ -15,8 +15,8 @@ template:
     {{- with $ctx.Values.machineSSHKeyName }}
     sshKeyName: {{ . }}
     {{- end }}
-    {{- with $nodeGroup.machineRootVolume }}
-    rootVolume: {{ toYaml . | nindent 6 }}
+    {{- if $nodeGroup.machineRootVolume.diskSize }}
+    rootVolume: {{ toYaml $nodeGroup.machineRootVolume | nindent 6 }}
     {{- end }}
     {{- if $ctx.Values.machineImageId }}
     imageUUID: {{ $ctx.Values.machineImageId }}

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -140,9 +140,9 @@ controlPlane:
     networks:
     ports:
   # The root volume spec for control plane machines
-  # If not given, the ephemeral root disk from the flavor is used
   machineRootVolume:
-    # The size of the disk to use
+    # The size of the disk to use
+    # If not given, the ephemeral root disk from the flavor is used
     diskSize:
     # The volume type to use
     # If not specified, the default volume type is used
@@ -229,9 +229,9 @@ nodeGroupDefaults:
     networks:
     ports:
   # The root volume spec for machines in the node group
-  # If not given, the ephemeral root disk from the flavor is used
   machineRootVolume:
-    # The size of the disk to use
+    # The size of the disk to use
+    # If not given, the ephemeral root disk from the flavor is used
     diskSize:
     # The volume type to use
     # If not specified, the default volume type is used

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -142,13 +142,13 @@ controlPlane:
   # The root volume spec for control plane machines
   # If not given, the ephemeral root disk from the flavor is used
   machineRootVolume:
-    # # The size of the disk to use
-    # diskSize:
-    # # The volume type to use
-    # # If not specified, the default volume type is used
+    # The size of the disk to use
+    diskSize:
+    # The volume type to use
+    # If not specified, the default volume type is used
     # volumeType:
-    # # The volume availability zone to use
-    # # If not specified, the machine availability zone is used
+    # The volume availability zone to use
+    # If not specified, the machine availability zone is used
     # availabilityZone:
   # The time to wait for a node to finish draining before it can be removed
   nodeDrainTimeout: 5m0s
@@ -231,13 +231,13 @@ nodeGroupDefaults:
   # The root volume spec for machines in the node group
   # If not given, the ephemeral root disk from the flavor is used
   machineRootVolume:
-    # # The size of the disk to use
-    # diskSize:
-    # # The volume type to use
-    # # If not specified, the default volume type is used
+    # The size of the disk to use
+    diskSize:
+    # The volume type to use
+    # If not specified, the default volume type is used
     # volumeType:
-    # # The volume availability zone to use
-    # # If not specified, the machine availability zone is used
+    # The volume availability zone to use
+    # If not specified, the machine availability zone is used
     # availabilityZone:
   # The time to wait for a node to finish draining before it can be removed
   nodeDrainTimeout: 5m0s


### PR DESCRIPTION
When used in Azimuth, this will allow the volume type and AZ to be specified globally or by the template while allowing the individual cluster to specify volume sizes without worrying about conditional merges.