### PR TITLE
Use an app token so that automation PRs trigger workflows

### DIFF
--- a/.github/scripts/generate-app-token
+++ b/.github/scripts/generate-app-token
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import time
+
+import jwt
+import requests
+
+
+parser = argparse.ArgumentParser(
+    description = "Generates a token to authenticate with a repository as a GitHub app."
+)
+parser.add_argument("repo", help = "The repo that the app token should be for.")
+parser.add_argument("app_id", help = "The ID of the app.")
+parser.add_argument("app_private_key", help = "The private key for the app.")
+args = parser.parse_args()
+
+
+# https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation
+
+# First, we need to make a JWT for the app
+iat = int(time.time())
+payload = { "iat": iat, "exp": iat + 600, "iss": args.app_id }
+encoded_jwt = jwt.encode(payload, args.app_private_key, algorithm = "RS256")
+
+# Use the JWT to get the access token URL for the repo installation
+response = requests.get(
+    f"https://api.github.com/repos/{args.repo}/installation",
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {encoded_jwt}",
+    }
+)
+response.raise_for_status()
+access_token_url = response.json()["access_tokens_url"]
+
+# Use the installation ID to get an access token for the repo
+response = requests.post(
+    access_token_url,
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {encoded_jwt}",
+    },
+    json = {
+        "repositories": [
+            # Because the installation is associated with an org or user,
+            # we only need to specify the name part of the repo here
+            args.repo.split("/", maxsplit = 1)[-1],
+        ],
+    }
+)
+response.raise_for_status()
+token = response.json()["token"]
+
+# Output the token so it can be consumed by later steps
+output_path = os.environ.get("GITHUB_OUTPUT", "/dev/stdout")
+with open(output_path, "a") as fh:
+    print(f"token={token}", file = fh)

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,3 +1,4 @@
-requests
 easysemver @ git+https://github.com/stackhpc/easysemver
+pyjwt
 pyyaml
+requests

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -80,12 +80,22 @@ jobs:
               steps.github-update-version.outputs.next-version
             }}
 
+      - name: Generate app token for PR
+        id: generate-app-token
+        run: >
+          .github/scripts/generate-app-token "$REPO" "$APP_ID" "$APP_PRIVATE_KEY"
+        env:
+          REPO: ${{ github.repository }}
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Propose changes via PR if required
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ steps.generate-app-token.outputs.token }}
           commit-message: >-
             Update ${{ matrix.key }} to ${{ steps.next.outputs.version }}
-          branch: update/${{ matrix.key }}
+          branch: update-dependency/${{ matrix.key }}
           delete-branch: true
           title: >-
             Update ${{ matrix.key }} to ${{ steps.next.outputs.version }}


### PR DESCRIPTION
This PR adds the ability to use a GitHub App token to authenticate PRs that are created to update dependencies. This means that those PRs will be able to trigger automation like the PR tests.