### PR TITLE
Separate machine image for control plane and worker nodes

### DIFF
--- a/charts/openstack-cluster/templates/control-plane/kubeadm-control-plane.yaml
+++ b/charts/openstack-cluster/templates/control-plane/kubeadm-control-plane.yaml
@@ -76,7 +76,7 @@ metadata:
     helm.sh/resource-policy: keep
     # NOTE: Argo won't delete this object itself as it has an owner reference to the cluster
 spec:
-  version: v{{ .Values.kubernetesVersion | required ".Values.kubernetesVersion is required" | trimPrefix "v" }}
+  version: v{{ .Values.controlPlane.kubernetesVersion | default .Values.kubernetesVersion | required "One of .Values.controlPlane.kubernetesVersion or .Values.kubernetesVersion is required" | trimPrefix "v" }}
   replicas: {{ .Values.controlPlane.machineCount }}
   rolloutStrategy: {{ toYaml .Values.controlPlane.rolloutStrategy | nindent 4 }}
   machineTemplate:

--- a/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
@@ -16,12 +16,16 @@ template:
     {{- if .Values.controlPlane.machineRootVolume.diskSize }}
     rootVolume: {{ toYaml .Values.controlPlane.machineRootVolume | nindent 6 }}
     {{- end }}
-    {{- if .Values.machineImageId }}
+    {{- if .Values.controlPlane.machineImageId }}
+    imageUUID: {{ .Values.controlPlane.machineImageId }}
+    {{- else if .Values.controlPlane.machineImage }}
+    image: {{ tpl .Values.controlPlane.machineImage . }}
+    {{- else if .Values.machineImageId }}
     imageUUID: {{ .Values.machineImageId }}
     {{- else if .Values.machineImage }}
     image: {{ tpl .Values.machineImage . }}
     {{- else }}
-    {{- fail "Either machineImage or machineImageId is required" }}
+    {{- fail "Either controlPlane.machineImageId, controlPlane.machineImage, machineImage or machineImageId is required" }}
     {{- end }}
     {{- with .Values.controlPlane.machineNetworking.ports }}
     ports: {{ toYaml . | nindent 6 }}

--- a/charts/openstack-cluster/templates/node-group/machine-deployment.yaml
+++ b/charts/openstack-cluster/templates/node-group/machine-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         {{ $.Values.projectPrefix }}/node-group: {{ $nodeGroup.name }}
     spec:
       clusterName: {{ include "openstack-cluster.clusterName" $ }}
-      version: v{{ trimPrefix "v" $.Values.kubernetesVersion }}
+      version: v{{ $nodeGroup.kubernetesVersion | default $.Values.kubernetesVersion | trimPrefix "v" }}
       {{- with $nodeGroup.failureDomain }}
       failureDomain: {{ . }}
       {{- end }}

--- a/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
@@ -18,12 +18,16 @@ template:
     {{- if $nodeGroup.machineRootVolume.diskSize }}
     rootVolume: {{ toYaml $nodeGroup.machineRootVolume | nindent 6 }}
     {{- end }}
-    {{- if $ctx.Values.machineImageId }}
+    {{- if $nodeGroup.machineImageId }}
+    imageUUID: {{ $nodeGroup.machineImageId }}
+    {{- else if $nodeGroup.machineImage }}
+    image: {{ tpl $nodeGroup.machineImage $ctx }}
+    {{- else if $ctx.Values.machineImageId }}
     imageUUID: {{ $ctx.Values.machineImageId }}
     {{- else if $ctx.Values.machineImage }}
     image: {{ tpl $ctx.Values.machineImage $ctx }}
     {{- else }}
-    {{- fail "Either machineImage or machineImageId is required" }}
+    {{- fail "Either nodeGroupDefaults.machineImageId, nodeGroupDefaults.machineImage, machineImageId or machineImage is required" }}
     {{- end }}
     {{- with $nodeGroup.machineNetworking.ports }}
     ports: {{ toYaml . | nindent 6 }}

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -127,6 +127,12 @@ controlPlane:
   # For high-availability, this should be greater than 1
   # For etcd quorum, it should be odd - usually 3, or 5 for very large clusters
   machineCount: 3
+  # The kubernetes version for the control plane
+  kubernetesVersion:
+  # The image to use for control plane
+  machineImage:
+  # The ID of the image to use for the control plane
+  machineImageId:
   # The flavor to use for control plane machines
   machineFlavor:
   # The ports for control plane nodes
@@ -223,6 +229,14 @@ nodeGroupDefaults:
   failureDomain:
   # The flavor to use for machines in the node group
   machineFlavor:
+  # Default image id for nodeGroup hosts
+  machineImage:
+  # The ID of the image to use for nodeGroup machines
+  machineImageId:
+  # Kubernetes version for nodeGroup machines
+  kubernetesVersion:
+  # The default networks and ports for worker nodes
+  # If neither networks or ports are given, the cluster internal network is used
   # The default ports for worker nodes
   # If no ports are given, the cluster internal network is used
   # See https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/docs/book/src/clusteropenstack/configuration.md#network-filters


### PR DESCRIPTION
To satisfy the [version skew policy](https://kubernetes.io/releases/version-skew-policy/) it would be useful if 
control plane and machine deployment nodes could be updated separately. This would allow us to update the control plane first and then update the worker nodes.

This checks if machineImage and kubernetesVersion are defined for the separate control plane/nodegroup and falls back to the root one if not.

~~Allow separate (or no) imagePrefix for addons~~