### PR TITLE
Remove image prefix

### DIFF
--- a/charts/cluster-addons/templates/_helpers.tpl
+++ b/charts/cluster-addons/templates/_helpers.tpl
@@ -37,10 +37,3 @@ helm.sh/chart: {{ index . 0 | include "cluster-addons.chart" }}
 capi.stackhpc.com/managed-by: {{ (index . 0).Release.Service }}
 {{ include "cluster-addons.componentSelectorLabels" . }}
 {{- end -}}
-
-{{/*
-Prefix to use for images
-*/}}
-{{- define "cluster-addons.imagePrefix" -}}
-{{- .Values.imagePrefix | default .Values.global.imagePrefix | default "" -}}
-{{- end -}}

--- a/charts/cluster-addons/templates/cni/calico.yaml
+++ b/charts/cluster-addons/templates/cni/calico.yaml
@@ -9,10 +9,7 @@ metadata:
     addons.stackhpc.com/watch: ""
 stringData:
   defaults: |
-    tigeraOperator:
-      registry: {{ include "cluster-addons.imagePrefix" . }}quay.io
     installation:
-      registry: {{ include "cluster-addons.imagePrefix" . }}docker.io/
       nodeMetricsPort: 9091
       typhaMetricsPort: 9093
       calicoNetwork:

--- a/charts/cluster-addons/templates/cni/cilium.yaml
+++ b/charts/cluster-addons/templates/cni/cilium.yaml
@@ -9,38 +9,7 @@ metadata:
     addons.stackhpc.com/watch: ""
 stringData:
   defaults: |
-    image:
-      repository: {{ include "cluster-addons.imagePrefix" . }}quay.io/cilium/cilium
-    certgen:
-      image:
-        repository: {{ include "cluster-addons.imagePrefix" . }}quay.io/cilium/certgen
-    hubble:
-      relay:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}quay.io/cilium/hubble-relay
-      ui:
-        backend:
-          image:
-            repository: {{ include "cluster-addons.imagePrefix" . }}quay.io/cilium/hubble-ui-backend
-        frontend:
-          image:
-            repository: {{ include "cluster-addons.imagePrefix" . }}quay.io/cilium/hubble-ui
-    operator:
-      image:
-        repository: {{ include "cluster-addons.imagePrefix" . }}quay.io/cilium/operator
-    nodeinit:
-      image:
-        repository: {{ include "cluster-addons.imagePrefix" . }}quay.io/cilium/startup-script
-    preflight:
-      image:
-        repository: {{ include "cluster-addons.imagePrefix" . }}quay.io/cilium/cilium
-    clustermesh:
-      apiserver:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}quay.io/cilium/clustermesh-apiserver
-      etcd:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}quay.io/coreos/etcd"
+    {}
   overrides: |
     {{- toYaml .Values.cni.cilium.release.values | nindent 4 }}
 ---

--- a/charts/cluster-addons/templates/ingress-nginx.yaml
+++ b/charts/cluster-addons/templates/ingress-nginx.yaml
@@ -16,15 +16,6 @@ stringData:
         serviceMonitor:
           enabled: true
       {{- end }}
-      image:
-        registry: {{ include "cluster-addons.imagePrefix" . }}registry.k8s.io
-    admissionWebhooks:
-      patch:
-        image:
-          registry: {{ include "cluster-addons.imagePrefix" . }}registry.k8s.io
-    defaultBackend:
-      image:
-        registry: {{ include "cluster-addons.imagePrefix" . }}registry.k8s.io
   overrides: |
     {{- toYaml .Values.ingress.nginx.release.values | nindent 4 }}
 ---

--- a/charts/cluster-addons/templates/kubernetes-dashboard.yaml
+++ b/charts/cluster-addons/templates/kubernetes-dashboard.yaml
@@ -10,12 +10,8 @@ metadata:
 stringData:
   # Enable the metrics scraper by default
   defaults: |
-    image:
-      repository: {{ include "cluster-addons.imagePrefix" . }}docker.io/kubernetesui/dashboard
     metricsScraper:
       enabled: true
-      image:
-        repository: {{ include "cluster-addons.imagePrefix" . }}docker.io/kubernetesui/metrics-scraper
   overrides: |
     {{- toYaml .Values.kubernetesDashboard.release.values | nindent 4 }}
 ---

--- a/charts/cluster-addons/templates/mellanox-network-operator.yaml
+++ b/charts/cluster-addons/templates/mellanox-network-operator.yaml
@@ -9,8 +9,6 @@ metadata:
     addons.stackhpc.com/watch: ""
 stringData:
   defaults: |
-    operator:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
     # Use the shared NFD
     nfd:
       enabled: false
@@ -19,7 +17,6 @@ stringData:
     # Deploy the OFED driver onto nodes with a suitable NIC
     ofedDriver:
       deploy: true
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/mellanox
       # OFED takes ages to deploy on low-resource nodes
       # The startup probe has a fixed failure threshold of 60
       # So in order to give the drivers up to one hour to install, we use a period
@@ -30,29 +27,17 @@ stringData:
     # Deploy the RDMA shared device plugin to allow pods to access the RDMA device
     rdmaSharedDevicePlugin:
       deploy: true
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
     # Disable all other features for now
     ibKubernetes:
       deploy: false
-      repository: {{ include "cluster-addons.imagePrefix" . }}ghcr.io/mellanox
     nvPeerDriver:
       deploy: false
-      repository: {{ include "cluster-addons.imagePrefix" . }}docker.io/mellanox
     sriovNetworkOperator:
       enabled: false
     sriovDevicePlugin:
       deploy: false
-      repository: {{ include "cluster-addons.imagePrefix" . }}ghcr.io/k8snetworkplumbingwg
     secondaryNetwork:
       deploy: false
-      cniPlugins:
-        repository: {{ include "cluster-addons.imagePrefix" . }}ghcr.io/k8snetworkplumbingwg
-      multus:
-        repository: {{ include "cluster-addons.imagePrefix" . }}ghcr.io/k8snetworkplumbingwg
-      ipoib:
-        repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
-      ipamPlugin:
-        repository: {{ include "cluster-addons.imagePrefix" . }}ghcr.io/k8snetworkplumbingwg
   overrides: |
     {{- toYaml .Values.mellanoxNetworkOperator.release.values | nindent 4 }}
 ---

--- a/charts/cluster-addons/templates/metrics-server.yaml
+++ b/charts/cluster-addons/templates/metrics-server.yaml
@@ -9,8 +9,6 @@ metadata:
     addons.stackhpc.com/watch: ""
 stringData:
   defaults: |
-    image:
-      repository: {{ include "cluster-addons.imagePrefix" . }}k8s.gcr.io/metrics-server/metrics-server
     args:
       - --kubelet-insecure-tls
   overrides: |

--- a/charts/cluster-addons/templates/monitoring/kube-prometheus-stack.yaml
+++ b/charts/cluster-addons/templates/monitoring/kube-prometheus-stack.yaml
@@ -43,8 +43,6 @@ stringData:
         route:
           group_by: ['...']
       alertmanagerSpec:
-        image:
-          registry: {{ include "cluster-addons.imagePrefix" . }}quay.io
         # Make sure that alertmanager finds configurations with the alertmanager name as a label
         alertmanagerConfigSelector:
           matchLabels:
@@ -52,22 +50,8 @@ stringData:
         # Do NOT add the namespace matcher to routes from AlertmanagerConfig resources
         alertmanagerConfigMatcherStrategy:
           type: None
-    prometheusOperator:
-      admissionWebhooks:
-        patch:
-          image:
-            registry: {{ include "cluster-addons.imagePrefix" . }}registry.k8s.io
-      image:
-        registry: {{ include "cluster-addons.imagePrefix" . }}quay.io
-      prometheusConfigReloader:
-        image:
-          registry: {{ include "cluster-addons.imagePrefix" . }}quay.io
-      thanosImage:
-        registry: {{ include "cluster-addons.imagePrefix" . }}quay.io
     prometheus:
       prometheusSpec:
-        image:
-          registry: {{ include "cluster-addons.imagePrefix" . }}quay.io
         # Tell Prometheus to pick up all monitors and alerting rules, regardless of labels
         podMonitorSelectorNilUsesHelmValues: false
         serviceMonitorSelectorNilUsesHelmValues: false
@@ -78,33 +62,11 @@ stringData:
         {{- $storageUnits := mustRegexFind "(K|M|G|T|E|P)i?$" $prometheusVolumeSize }}
         retentionSize: {{ mulf 0.95 $storageAmount }}{{ $storageUnits }}B
         {{- end }}
-    thanosRuler:
-      thanosRulerSpec:
-        image:
-          registry: {{ include "cluster-addons.imagePrefix" . }}quay.io
-    kube-state-metrics:
-      image:
-        repository: {{ include "cluster-addons.imagePrefix" . }}registry.k8s.io/kube-state-metrics/kube-state-metrics
-    prometheus-node-exporter:
-      image:
-        registry: {{ include "cluster-addons.imagePrefix" . }}quay.io
     grafana:
-      image:
-        repository: {{ include "cluster-addons.imagePrefix" . }}docker.io/grafana/grafana
       sidecar:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}quay.io/kiwigrid/k8s-sidecar
         # Tell Grafana to include dashboards from all namespaces
         dashboards:
           searchNamespace: ALL
-      downloadDashboardsImage:
-        repository: {{ include "cluster-addons.imagePrefix" . }}docker.io/curlimages/curl
-      initChownData:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}docker.io/busybox
-      imageRenderer:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}docker.io/grafana/grafana-image-renderer
   overrides: |
     {{- toYaml .Values.monitoring.kubePrometheusStack.release.values | nindent 4 }}
 ---

--- a/charts/cluster-addons/templates/monitoring/loki-stack.yaml
+++ b/charts/cluster-addons/templates/monitoring/loki-stack.yaml
@@ -10,13 +10,9 @@ metadata:
 stringData:
   defaults: |
     loki:
-      image:
-        repository: {{ include "cluster-addons.imagePrefix" . }}docker.io/grafana/loki
       serviceMonitor:
         enabled: true
     promtail:
-      image:
-        registry: {{ include "cluster-addons.imagePrefix" . }}docker.io
       serviceMonitor:
         enabled: true
       # Get promtail to scrape systemd services

--- a/charts/cluster-addons/templates/nfd.yaml
+++ b/charts/cluster-addons/templates/nfd.yaml
@@ -14,8 +14,6 @@ metadata:
     addons.stackhpc.com/watch: ""
 stringData:
   defaults: |
-    image:
-      repository: {{ include "cluster-addons.imagePrefix" . }}registry.k8s.io/nfd/node-feature-discovery
     master:
       extraLabelNs:
         - nvidia.com

--- a/charts/cluster-addons/templates/nvidia-gpu-operator.yaml
+++ b/charts/cluster-addons/templates/nvidia-gpu-operator.yaml
@@ -9,40 +9,6 @@ metadata:
     addons.stackhpc.com/watch: ""
 stringData:
   defaults: |
-    validator:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
-    operator:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia
-      initContainer:
-        repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia
-    driver:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia
-      manager:
-        repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
-    devicePlugin:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia
-    dcgm:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
-    dcgmExporter:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/k8s
-    gfd:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia
-    migManager:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
-    gds:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
-    vgpuManager:
-      repository: {{ include "cluster-addons.imagePrefix" . | quote }}
-      driverManager:
-        repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
-    vgpuDeviceManager:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
-    vfioManager:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia
-      driverManager:
-        repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
-    sandboxDevicePlugin:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia
     # Use the shared NFD
     nfd:
       enabled: false
@@ -51,9 +17,7 @@ stringData:
     # operator (e.g. reconciliation status, number of GPU enabled nodes).
     nodeStatusExporter:
       enabled: true
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/cloud-native
     toolkit:
-      repository: {{ include "cluster-addons.imagePrefix" . }}nvcr.io/nvidia/k8s
       # Allowing the toolkit to edit /etc/containerd/config.toml (the default)
       # breaks nvidia pod deployment on clusters with Harbor cache enabled.
       # Instead make a new config file specifically for nvidia runtime config,

--- a/charts/cluster-addons/templates/openstack/ccm.yaml
+++ b/charts/cluster-addons/templates/openstack/ccm.yaml
@@ -9,8 +9,6 @@ metadata:
     addons.stackhpc.com/watch: ""
 stringData:
   defaults: |
-    image:
-      repository: {{ include "cluster-addons.imagePrefix" . }}registry.k8s.io/provider-os/openstack-cloud-controller-manager
     secret:
       create: false
     cluster:

--- a/charts/cluster-addons/templates/openstack/csi-cinder.yaml
+++ b/charts/cluster-addons/templates/openstack/csi-cinder.yaml
@@ -12,27 +12,7 @@ stringData:
   # We deploy our own instead as it gives us more control over the parameters
   defaults: |
     csi:
-      attacher:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}k8s.gcr.io/sig-storage/csi-attacher
-      provisioner:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}k8s.gcr.io/sig-storage/csi-provisioner
-      snapshotter:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}k8s.gcr.io/sig-storage/csi-snapshotter
-      resizer:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}k8s.gcr.io/sig-storage/csi-resizer
-      livenessprobe:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}k8s.gcr.io/sig-storage/livenessprobe
-      nodeDriverRegistrar:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}k8s.gcr.io/sig-storage/csi-node-driver-registrar
       plugin:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}docker.io/k8scloudprovider/cinder-csi-plugin
         # This has to be non-empty or the chart fails to render
         volumes:
           - name: cacert
@@ -44,9 +24,6 @@ stringData:
           - name: cloud-config
             mountPath: /etc/kubernetes
             readOnly: true
-      snapshotController:
-        image:
-          repository: {{ include "cluster-addons.imagePrefix" . }}k8s.gcr.io/sig-storage/snapshot-controller
     secret:
       enabled: true
       create: false

--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -1,10 +1,5 @@
 ---
 
-global:
-  # The prefix to use for images
-  # This setting is shared with the parent cluster
-  imagePrefix:
-
 # The name of the Cluster API cluster
 # if not given, the release name is used
 clusterName:
@@ -30,10 +25,6 @@ hooks:
   tolerations: []
   nodeSelector: {}
   affinity: {}
-
-# The prefix to use for addon images
-# Takes precedence over the global setting if given
-imagePrefix:
 
 # Settings for the CNI addon
 cni:

--- a/charts/openstack-cluster/templates/_helpers.tpl
+++ b/charts/openstack-cluster/templates/_helpers.tpl
@@ -215,11 +215,3 @@ preKubeadmCommands:
   {{- end }}
 {{- end }}
 {{- end }}
-
-{{/*
-Produces the image for the cluster autoscaler.
-*/}}
-{{- define "openstack-cluster.autoscaler.image" -}}
-{{- $prefix := .Values.autoscaler.image.prefix | default .Values.global.imagePrefix | default "" }}
-{{- printf "%s%s:%s" $prefix .Values.autoscaler.image.repository .Values.autoscaler.image.tag -}}
-{{- end }}

--- a/charts/openstack-cluster/templates/autoscaler/deployment.yaml
+++ b/charts/openstack-cluster/templates/autoscaler/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: autoscaler
           securityContext: {{ toYaml .Values.autoscaler.securityContext | nindent 12 }}
-          image: {{ printf "%s:%s" .Values.autoscaler.image.repository .Values.autoscaler.image.tag -}}
+          image: {{ printf "%s:%s" .Values.autoscaler.image.repository .Values.autoscaler.image.tag }}
           imagePullPolicy: {{ .Values.autoscaler.image.pullPolicy }}
           command:
             - /cluster-autoscaler

--- a/charts/openstack-cluster/templates/autoscaler/deployment.yaml
+++ b/charts/openstack-cluster/templates/autoscaler/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: autoscaler
           securityContext: {{ toYaml .Values.autoscaler.securityContext | nindent 12 }}
-          image: {{ include "openstack-cluster.autoscaler.image" . }}
+          image: {{ printf "%s:%s" .Values.autoscaler.image.repository .Values.autoscaler.image.tag -}}
           imagePullPolicy: {{ .Values.autoscaler.image.pullPolicy }}
           command:
             - /cluster-autoscaler

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -1,10 +1,5 @@
 ---
 
-global:
-  # The prefix to use for images
-  # This setting is shared with the addons
-  imagePrefix:
-
 # The name of an existing secret containing a clouds.yaml and optional cacert
 cloudCredentialsSecretName:
 # OR


### PR DESCRIPTION
This completes the work done in #93.

The `imagePrefix` has caught us out a few times with changes to repositories, and is a nightmare to maintain. It is being removed in favour of implicit mirroring.