### PR TITLE
Revert ingress-nginx to 4.8.3

### DIFF
--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -153,7 +153,7 @@ ingress:
     chart:
       repo: https://kubernetes.github.io/ingress-nginx
       name: ingress-nginx
-      version: 4.8.4
+      version: 4.8.3
     release:
       namespace: ingress-nginx
 


### PR DESCRIPTION
The 4.8.4 release was revoked 