### PR TITLE
Add global network policy to block access to metaservice

### DIFF
--- a/charts/cluster-addons/templates/cni/calico.yaml
+++ b/charts/cluster-addons/templates/cni/calico.yaml
@@ -49,6 +49,73 @@ spec:
     - secret:
         name: {{ include "cluster-addons.componentName" (list . "cni-calico") }}-config
         key: overrides
+{{- if .Values.cni.calico.globalNetworkPolicy }}
+---
+apiVersion: addons.stackhpc.com/v1alpha1
+kind: Manifests
+metadata:
+  name: {{ include "cluster-addons.componentName" (list . "cni-calico-globalnetpolicy") }}
+  labels: {{ include "cluster-addons.componentLabels" (list . "cni-calico-globalnetpolicy") | nindent 4 }}
+  annotations:
+    # Tell Argo to ignore the non-controller owner references for this object
+    argocd.argoproj.io/sync-options: "ControllerReferencesOnly=true"
+spec:
+  clusterName: {{ include "cluster-addons.clusterName" . }}
+  bootstrap: true
+  targetNamespace: {{ .Values.cni.calico.release.namespace }}
+  releaseName: cni-calico-metadata-global-netpolicy
+  manifestSources:
+    - template: |
+        ---
+        apiVersion: projectcalico.org/v3
+        kind: GlobalNetworkPolicy
+        metadata:
+          name: {{ include "cluster-addons.componentName" (list . "deny-egress") }}
+        spec:
+          order: {{ .Values.cni.calico.globalNetworkPolicy.denyPriority }}
+          namespaceSelector: {{ .Values.cni.calico.globalNetworkPolicy.denyNamespaceSelector }}
+          types:
+            - Egress
+          egress:
+            - action: Deny
+              ipVersion: 4
+              destination:
+                nets:
+                {{- range .Values.cni.calico.globalNetworkPolicy.denyEgressCidrs }}
+                  - {{ . }}
+                {{ end }}
+            - action: Deny
+              ipVersion: 6
+              destination:
+                nets:
+                {{- range .Values.cni.calico.globalNetworkPolicy.denyv6EgressCidrs }}
+                  - {{ . }}
+                {{ end }}
+        ---
+        apiVersion: projectcalico.org/v3
+        kind: GlobalNetworkPolicy
+        metadata:
+          name: {{ include "cluster-addons.componentName" (list . "allow-global-egress") }}
+        spec:
+          order: {{ .Values.cni.calico.globalNetworkPolicy.allowPriority }}
+          types:
+            - Egress
+          egress:
+            - action: Allow
+              ipVersion: 4
+              destination:
+                nets: 
+                {{- range .Values.cni.calico.globalNetworkPolicy.allowEgressCidrs }}
+                  - {{ . }}
+                {{ end }}
+            - action: Allow
+              ipVersion: 6
+              destination:
+                nets: 
+                {{- range .Values.cni.calico.globalNetworkPolicy.allowv6EgressCidrs }}
+                  - {{ . }}
+                {{ end }}
+{{- end }}
 {{- if .Values.monitoring.enabled }}
 ---
 apiVersion: addons.stackhpc.com/v1alpha1

--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -20,6 +20,20 @@ cni:
     release:
       namespace: tigera-operator
       values: {}
+    # Nova metadata service
+    # See https://docs.openstack.org/nova/latest/user/metadata.html#the-metadata-service
+    globalNetworkPolicy:
+      denyNamespaceSelector: kubernetes.io/metadata.name != 'openstack-system'
+      allowPriority: 20
+      denyPriority: 10
+      allowEgressCidrs:
+        - "0.0.0.0/0"
+      denyEgressCidrs:
+        - "169.254.169.254/32"
+      allowv6EgressCidrs:
+        - "::/0"
+      denyv6EgressCidrs:
+        - "fe80::a9fe:a9fe/128"
   # Settings for the Cilium CNI
   # See https://docs.cilium.io/en/stable/gettingstarted/k8s-install-helm/ for details
   cilium:


### PR DESCRIPTION
* Use calico GlobalNetworkPolicy to deny egress to metaservice
* basic values to for priority, deny and allow CIDR