### PR TITLE
Add pod disruption budget to metrics-server

### DIFF
--- a/charts/cluster-addons/templates/metrics-server.yaml
+++ b/charts/cluster-addons/templates/metrics-server.yaml
@@ -11,6 +11,10 @@ stringData:
   defaults: |
     args:
       - --kubelet-insecure-tls
+    # Since we deploy in kube-system, we need a PDB to allow eviction to happen
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 0
   overrides: |
     {{- toYaml .Values.metricsServer.release.values | nindent 4 }}
 ---


### PR DESCRIPTION
Pods for the metrics-server are currently in `kube-system` without a pod disruption budget, which is a category of pods that prevent scale down in auto-scaling clusters.