### PR TITLE
Improve cluster autoscaler default config

### DIFF
--- a/charts/openstack-cluster/templates/autoscaler/deployment.yaml
+++ b/charts/openstack-cluster/templates/autoscaler/deployment.yaml
@@ -32,6 +32,9 @@ spec:
             - --kubeconfig=/mnt/kubeconfig/value
             - --clusterapi-cloud-config-authoritative
             - --node-group-auto-discovery=clusterapi:namespace={{ .Release.Namespace }},clusterName={{ include "openstack-cluster.clusterName" . }}
+            {{- range $key, $value := .Values.autoscaler.extraArgs }}
+            - --{{ $key }}={{ $value }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /health-check

--- a/charts/openstack-cluster/templates/autoscaler/role.yaml
+++ b/charts/openstack-cluster/templates/autoscaler/role.yaml
@@ -8,7 +8,6 @@ rules:
       - cluster.x-k8s.io
     resources:
       - machinedeployments
-      - machinedeployments/scale
       - machines
       - machinesets
     verbs:
@@ -16,3 +15,11 @@ rules:
       - list
       - update
       - watch
+  - apiGroups:
+      - cluster.x-k8s.io
+    resources:
+      - machinedeployments/scale
+    verbs:
+      - get
+      - patch
+      - update

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -416,14 +416,28 @@ nodeGroups:
 autoscaler:
   # The image to use for the autoscaler component
   image:
-    # Defaults to the global image prefix if not given
-    prefix:
     repository: registry.k8s.io/autoscaling/cluster-autoscaler
     pullPolicy: IfNotPresent
-    # The cluster-autoscaler docs recommend using a version that matches the
-    # Kubernetes version, but versions should be (mostly) backwards-compatible
-    tag: v1.26.1
+    tag: v1.29.0
   imagePullSecrets: []
+  # Any extra args for the autoscaler
+  extraArgs:
+    # Make sure logs go to stderr
+    logtostderr: true
+    stderrthreshold: info
+    # Output at a decent log level
+    v: 4
+    # Cordon nodes before terminating them so new pods are not scheduled there
+    cordon-node-before-terminating: "true"
+    # When scaling up, choose the node group that will result in the least idle CPU after
+    expander: least-waste,random
+    # Allow pods in kube-system to prevent a node from being deleted
+    skip-nodes-with-system-pods: "true"
+    # Allow pods with emptyDirs to be evicted
+    skip-nodes-with-local-storage: "false"
+    # Allow pods with custom controllers to be evicted
+    skip-nodes-with-custom-controller-pods: "false"
+
   # Pod-level security context
   podSecurityContext:
     runAsNonRoot: true


### PR DESCRIPTION
In particular, allow pods with `emptyDir`s to be evicted, switch to the `least-waste` expander and increase the default log level.