### PR TITLE
Fix log ordering in Loki dashboards

### DIFF
--- a/charts/cluster-addons/grafana-dashboards/loki-pod-logs-dashboard.json
+++ b/charts/cluster-addons/grafana-dashboards/loki-pod-logs-dashboard.json
@@ -138,7 +138,7 @@
       "options": {
         "showLabels": false,
         "showTime": true,
-        "sortOrder": "Descending",
+        "sortOrder": "Ascending",
         "wrapLogMessage": true
       },
       "targets": [

--- a/charts/cluster-addons/grafana-dashboards/loki-systemd-logs-dashboard.json
+++ b/charts/cluster-addons/grafana-dashboards/loki-systemd-logs-dashboard.json
@@ -138,7 +138,7 @@
       "options": {
         "showLabels": false,
         "showTime": true,
-        "sortOrder": "Descending",
+        "sortOrder": "Ascending",
         "wrapLogMessage": true
       },
       "targets": [


### PR DESCRIPTION
At the moment these dashboards use newest first ordering which means that most recent log lines appear at the top rather than the bottom. This makes certain things difficult to read e.g. Python stack traces get split by lines so the trace lines appear reversed in the logs. This change fixes the ordering to make reading the logs easier.