### PR TITLE
Update k8s-keystone-auth subchart with working image

### DIFF
--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -124,9 +124,9 @@ openstack:
     enabled: false
     targetNamespace: kube-system
     chart:
-      repo: https://heytrav.github.io/helm-charts
+      repo: https://catalyst-cloud.github.io/capi-plugin-helm-charts
       name: k8s-keystone-auth
-      version: 0.0.9
+      version: 1.1.0
 
 # Settings for etcd defragmentation jobs
 etcdDefrag:


### PR DESCRIPTION
Just discovered that the image referenced in helm chart doesn't exist. Updated with a version that has an existing image.