### PR TITLE
Sort node-labels whilst iterating over keys

### DIFF
--- a/charts/openstack-cluster/templates/_helpers.tpl
+++ b/charts/openstack-cluster/templates/_helpers.tpl
@@ -131,7 +131,7 @@ Outputs the node registration object for setting node labels.
 {{- define "openstack-cluster.nodeRegistration.nodeLabels" -}}
 nodeRegistration:
   kubeletExtraArgs:
-    node-labels: "{{ range $i, $k := keys . }}{{ if ne $i 0 }},{{ end }}{{ $k }}={{ index $ $k }}{{ end }}"
+    node-labels: "{{ range $i, $k := (keys . | sortAlpha) }}{{ if ne $i 0 }},{{ end }}{{ $k }}={{ index $ $k }}{{ end }}"
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Sorts the node-labels whilst iterating through the keys of the un-ordered dict. This prevents a machine deployment flipping between n machine-sets.

Currently, each evaluation of the template could result in a different label order. Since the entire resource is hashed, this results in "upgrades" back and forth, depending on where we land in the unordered dict.

By sorting the keys, we at least ensure that the results are idempotent between helm template (or equiv.) runs.

I'm sure there's other places we rely on range implicitly being ordered, but doing a quick grep through, the other uses of range in openstack-cluster/helpers.tpl appear to not require this from a glance.

Testing
-----------

I've tested this locally with the following:

- Create multiple machine deployments to increase the chances of them flipping between:
```
nodeGroups:
  - name: default-md-0
    machineCount: 2
  - name: md-group-1
    machineFlavor: l3.nano
    machineCount: 2
  - name: md-group-2
    machineFlavor: l3.nano
    machineCount: 2
  - name: md-group-3
    machineFlavor: l3.nano
    machineCount: 2
  - name: md-group-4
    machineFlavor: l3.nano
    machineCount: 2
```

- Add some additional labels:
```
nodeGroupDefaults:
  nodeLabels:
    longhorn.store.nodeselect/longhorn-storage-node: true
    some-other-label.example.com: true
    some-third-label.example.com: 3
```

- Deploy using the upstream chart, and check the number of MachineSets (to replicate the issue)
- Helm upgrade a few times - if the number of machine sets increases the bug has been reproduced.
- Alternatively, if some MachineDeployment refer to invalid templates this is another symptom of the bug
- Uninstall the current chart, clear the machine sets
- Repeat above steps with this commit - notice a 1:1 nodeGroup:ms mapping
