### PR TITLE
Add workaround for pod instabilities observed when using Nvidia's container runtime

### DIFF
--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -183,7 +183,21 @@ ingress:
       version: 4.10.1
     release:
       namespace: ingress-nginx
-      values: {}
+      values:
+        controller:
+          # Try to mitigate unresolved issue with pod instability
+          # on nodes running the Nvidia container runtime
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: NotIn
+                    values:
+                    - "true"
+
 
 # Settings for cluster monitoring
 monitoring:
@@ -211,6 +225,18 @@ monitoring:
                   resources:
                     requests:
                       storage: 10Gi
+            # Try to mitigate unresolved issue with pod instability
+            # on nodes running the Nvidia container runtime
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                    - key: nvidia.com/gpu.present
+                      operator: NotIn
+                      values:
+                      - "true"
         prometheus:
           prometheusSpec:
             # The amount of data that is retained will be 90 days or 95% of the size of the


### PR DESCRIPTION
We're seeing intermittent issues with NGINX controller and Alertmanager (and CoreDNS) pods when they are scheduled to nodes which are using the Nvidia container runtime. The root cause of the issue needs more investigation, but adding some affinity rules where possible to discourage the problematic pods from landing on GPU nodes will improve the situation in the short term.